### PR TITLE
Generate split region from the distinct value of base table index

### DIFF
--- a/pkg/split/sampling.go
+++ b/pkg/split/sampling.go
@@ -14,3 +14,268 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package split
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql"
+	"fmt"
+	"github.com/WentaoJin/tidba/pkg/db"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+func GenerateSplitByBaseTable(engine *db.Engine, baseDB, baseTable, baseIndex, newDB, newTable, newIndex, outDir string, totalWriteRows int) error {
+	// 1. get distinct value.
+	s := &splitByBase{
+		baseDB:      baseDB,
+		baseTable:   baseTable,
+		baseIndex:   baseIndex,
+		newDB:       newDB,
+		newTable:    newTable,
+		newIndex:    newIndex,
+		outFilePath: path.Join(outDir, "split_by_base.sql"),
+	}
+	err := s.init(engine)
+	if err != nil {
+		return err
+	}
+	var wg sync.WaitGroup
+	var err1, err2 error
+	var regionCount int
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		err1 = s.getBaseDistinctValues(engine)
+	}()
+
+	go func() {
+		defer wg.Done()
+		regionCount, err2 = s.calculateRegionNum(engine, totalWriteRows)
+	}()
+	wg.Wait()
+
+	if err1 != nil {
+		return err1
+	}
+	if err2 != nil {
+		return err2
+	}
+
+	err = s.generateSplit(regionCount)
+	if err != nil {
+		return err2
+	}
+
+	s.close()
+	return nil
+}
+
+type splitByBase struct {
+	baseIndexInfo  IndexInfo
+	file           *os.File
+	fileWriter     *bufio.Writer
+	distinctValues [][]string
+
+	baseDB      string
+	baseTable   string
+	baseIndex   string
+	newDB       string
+	newTable    string
+	newIndex    string
+	outFilePath string
+}
+
+func (s *splitByBase) init(engine *db.Engine) error {
+	err := s.initOutFile()
+	if err != nil {
+		return err
+	}
+	err = s.getBaseTableIndex(engine)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *splitByBase) generateSplit(regionCount int) error {
+	if regionCount < 1 {
+		regionCount = 1
+	}
+	sqlBuf := bytes.NewBuffer(nil)
+	sqlBuf.WriteString(fmt.Sprintf("split table %s index %s by ", s.tableName(s.newDB, s.newTable), s.newIndex))
+	step := len(s.distinctValues) / regionCount
+	if step < 1 {
+		step = 1
+	}
+	for i := 0; i < len(s.distinctValues); i += step {
+		if i > 0 {
+			sqlBuf.WriteString(",")
+		}
+		vs := s.distinctValues[i]
+		sqlBuf.WriteString("(")
+		sqlBuf.WriteString(strings.Join(vs, ","))
+		sqlBuf.WriteString(")")
+	}
+
+	_, err := s.fileWriter.WriteString(sqlBuf.String() + ";\n\n")
+	return err
+}
+
+func (s *splitByBase) initOutFile() error {
+	outFile, err := os.OpenFile(s.outFilePath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	s.fileWriter, s.file = bufio.NewWriter(outFile), outFile
+	return nil
+}
+
+func (s *splitByBase) close() {
+	if s.file != nil {
+		s.fileWriter.Flush()
+		s.file.Close()
+	}
+}
+
+func (s *splitByBase) getBaseTableIndex(engine *db.Engine) error {
+	s.baseIndexInfo = IndexInfo{
+		IndexName:  s.baseIndex,
+		ColumnName: nil,
+	}
+	condition := fmt.Sprintf("where lower(table_name)=lower('%s') and lower(table_schema)=lower('%s') and lower(KEY_NAME) = lower ('%s')",
+		s.baseTable, s.baseDB, s.baseIndex)
+	query := fmt.Sprintf("select COLUMN_NAME from INFORMATION_SCHEMA.TIDB_INDEXES %s", condition)
+	err := queryRows(engine.DB, query, func(row, cols []string) error {
+		if len(row) != 1 {
+			panic("result row is not index column name, should never happen")
+		}
+		s.baseIndexInfo.ColumnName = append(s.baseIndexInfo.ColumnName, row[0])
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(s.baseIndexInfo.ColumnName) == 0 {
+		return fmt.Errorf("unknow index %v in %v", s.baseIndex, s.tableName(s.baseDB, s.baseTable))
+	}
+	return err
+}
+
+func (s *splitByBase) getBaseDistinctValues(engine *db.Engine) error {
+	idxCols := strings.Join(s.baseIndexInfo.ColumnName, ",")
+	query := fmt.Sprintf("select distinct %s from %s order by %s",
+		idxCols, s.tableName(s.baseDB, s.baseTable), idxCols)
+	rows, err := queryAllRows(engine.DB, query)
+	if err != nil {
+		return err
+	}
+	s.distinctValues = rows
+	return nil
+}
+
+func (s *splitByBase) calculateRegionNum(engine *db.Engine, totalWriteRows int) (int, error) {
+	baseRows, err := s.getBaseTableCount(engine)
+	if err != nil {
+		return 0, err
+	}
+	baseIndexRegions, err := s.getBaseTableIndexRegionCount(engine)
+	if err != nil {
+		return 0, err
+	}
+	if baseIndexRegions < 1 {
+		baseIndexRegions = 1
+	}
+	capacity := baseRows / baseIndexRegions
+	if capacity < 10000 {
+		capacity = 10000
+	}
+	count := totalWriteRows / capacity
+	if count < 1 {
+		count = 1
+	}
+	return count, nil
+}
+
+func (s *splitByBase) getBaseTableCount(engine *db.Engine) (int, error) {
+	count := 0
+	query := fmt.Sprintf("select count(1) from %v", s.tableName(s.baseDB, s.baseTable))
+	err := queryRows(engine.DB, query, func(row, cols []string) error {
+		if len(row) != 1 {
+			panic("result row is not row counts, should never happen")
+		}
+		v, err := strconv.Atoi(row[0])
+		if err != nil {
+			return err
+		}
+		count = v
+		return nil
+	})
+	return count, err
+}
+
+func (s *splitByBase) getBaseTableIndexRegionCount(engine *db.Engine) (int, error) {
+	count := 0
+	query := fmt.Sprintf("show table %s index %s regions", s.tableName(s.baseDB, s.baseTable), s.baseIndex)
+	err := queryRows(engine.DB, query, func(row, cols []string) error {
+		count++
+		return nil
+	})
+	return count, err
+}
+
+func (s *splitByBase) tableName(db, table string) string {
+	return fmt.Sprintf("%s.%s", db, table)
+}
+
+func queryAllRows(Engine *sql.DB, SQL string) ([][]string, error) {
+	rows, err := Engine.Query(SQL)
+	if err == nil {
+		defer rows.Close()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	cols, err1 := rows.Columns()
+	if err1 != nil {
+		return nil, err1
+	}
+	// Read all rows.
+	var actualRows [][]string
+	for rows.Next() {
+
+		rawResult := make([][]byte, len(cols))
+		result := make([]string, len(cols))
+		dest := make([]interface{}, len(cols))
+		for i := range rawResult {
+			dest[i] = &rawResult[i]
+		}
+
+		err1 = rows.Scan(dest...)
+		if err1 != nil {
+			return nil, err1
+		}
+
+		for i, raw := range rawResult {
+			if raw == nil {
+				result[i] = "NULL"
+			} else {
+				val := string(raw)
+				result[i] = "'" + val + "'"
+			}
+		}
+
+		actualRows = append(actualRows, result)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return actualRows, nil
+}


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

```sql
前提：给基础表相关的字段也添加相同的索引定义。
假设基础表的表结构是 create table t (a int, b int, index (b));

1. 取 distinct 并排序后 （ 例如：select distinct b from t order by b; ） 的数据存到数组 array。假设 array 是 1 到 50000 （ [1,2,3,4,.... 50000] ）
2. 计算要切的 region 数量。假设 new-table-rows 是 1000 w 行
   * 获取基础表 t 中索引 b 的总 region 数： show table t index b regions;  假如是 10 个 region 
   * 获取基础表 t 的总行数，假如是 100 w 行
   * 那么每个 region 能存 10w (100w/10) 个索引数据
   * 用 new-table-rows (新表要写入总行数) / 10w 得到要切的 region 的个数为 100 个
3. 计算要切 100 个 region 的分界点，其实就是从第一步中的 array 中等比分成 100 份，找到分界点即可。
```

usage:

```sql
go run main.go split sampling --new-table-row 100000000 --base-db test --base-table t --base-index idx --new-db test --new-table t1 --new-index idxx

cat /tmp/split/split_by_base.sql
```